### PR TITLE
Add quotes to virtualenv template

### DIFF
--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -20,7 +20,7 @@ sh_activate_tpl = Template(textwrap.dedent("""
         export "$LINE";
     done < "{{ environment_file }}"
 
-    export CONAN_OLD_PS1=$PS1
+    export CONAN_OLD_PS1="$PS1"
     export PS1="({{venv_name}}) $PS1"
 
 """))


### PR DESCRIPTION
Fix https://github.com/conan-io/conan/issues/6264 with required quotes

Changelog: (Feature | Fix | Bugfix): Fix for https://github.com/conan-io/conan/issues/6264

- [x] Refer to the issue that supports this Pull Request.
- N/A If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- N/A I've followed the PEP8 style guides for Python code.
- N/A I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
